### PR TITLE
Allow use for single page applications

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -21,6 +21,7 @@ You can literally copy and paste the following example, change the following att
 * `domain`: set to your static website's base domain name (e.g., `xyz.com`)
 * `cf_ipv6_enabled`: default is `true`,
 enable https://aws.amazon.com/about-aws/whats-new/2016/10/ipv6-support-for-cloudfront-waf-and-s3-transfer-acceleration/[CloudFront IPV6] feature.
+* `single_page_application`: default is `false`. If `true`, redirects all `404 errors` to the specified `index_document` variable.
 
 
 [source,hcl]

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -52,8 +52,8 @@ resource "aws_cloudfront_distribution" "main" {
   custom_error_response {
     error_code            = "404"
     error_caching_min_ttl = "300"
-    response_code         = var.error_response_code
-    response_page_path    = "/${var.error_document}"
+    response_code         = var.single_page_application ? var.spa_error_response_code : var.error_response_code
+    response_page_path    = "/${var.single_page_application ? var.index_document : var.error_document}"
   }
 
   aliases = concat([var.fqdn], var.aliases)
@@ -142,8 +142,8 @@ resource "aws_cloudfront_distribution" "main-lambda-edge" {
   custom_error_response {
     error_code            = "404"
     error_caching_min_ttl = "300"
-    response_code         = var.error_response_code
-    response_page_path    = "/${var.error_document}"
+    response_code         = var.single_page_application ? var.spa_error_response_code : var.error_response_code
+    response_page_path    = "/${var.single_page_application ? var.index_document : var.error_document}"
   }
 
   aliases = concat([var.fqdn], var.aliases)

--- a/variables.tf
+++ b/variables.tf
@@ -68,6 +68,12 @@ variable "error_response_code" {
   default     = "404"
 }
 
+variable "spa_error_response_code" {
+  type        = string
+  description = "Response code to send on 404 for a single page application"
+  default     = "200"
+}
+
 variable "tags" {
   type        = map(string)
   description = "Tags"
@@ -87,5 +93,10 @@ variable "lambda_edge_enabled" {
 
 variable "cf_ipv6_enabled" {
   default = true
+  type = bool
+}
+
+variable "single_page_application" {
+  default = false
   type = bool
 }


### PR DESCRIPTION
Very simple change to allow use of this library with single page applications. With SPAs we need the application to handle all errors, so in both `cloudFront` resources I modify the `custom_error_response` to return a `200` response and point to the `index_document` file that was provided to the module.