### PR TITLE
Fix Tag "Name" is always follow `fqdn` value

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -23,10 +23,10 @@ resource "aws_s3_bucket" "main" {
   acceleration_status = var.acceleration_status
 
   tags = merge(
-  var.tags,
   {
-    "Name" = var.fqdn
+    "Name" = local.localBucketName
   },
+  var.tags
   )
 }
 


### PR DESCRIPTION
Fix an issue where `fqdn` might contains value that is not allowed as part of tag value: https://docs.aws.amazon.com/directoryservice/latest/devguide/API_Tag.html which the user need to override the tag value in order to be deployed successfully.

Related to: https://github.com/riboseinc/terraform-aws-s3-cloudfront-website/issues/39